### PR TITLE
add default as a routetype

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1302,6 +1302,7 @@ definitions:
         - edge
         - passthrough
         - reencrypt
+        - default
       hostname:
         type: string
       port:


### PR DESCRIPTION
#### What does this PR do?

Adds `default` as a `RouteType`. This will be used in automation to expose the default route for an app. This makes a route definition required if the user wants their app exposed.
#### Which tests illustrate how this code works?
#### Is there a relevant Issue open for this?
#### Are there any other relevant resources that should be reviewed as well?
#### Who would you like to review this?

/cc @oybed @mdanter @mcanoy 
