### PR TITLE
Change engagement.groups to engagement.user_groups

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1096,7 +1096,7 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/User'
-      groups:
+      user_groups:
         type: array
         items:
           $ref: '#/definitions/Group'


### PR DESCRIPTION
#### What does this PR do?
Changes the field name groups to user_groups in the engagement definition.

#### Which tests illustrate how this code works?
n/a

#### Is there a relevant Issue open for this?
Fixes #59 

#### Are there any other relevant resources that should be reviewed as well?
n/a

#### Who would you like to review this?
/cc @sherl0cks 

